### PR TITLE
[DO NOT MERGE] Script to demonstrate the error where jarjar fails but returns 0.

### DIFF
--- a/lies.sh
+++ b/lies.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ant jar
+curl -o corrupt.jar "http://central.maven.org/maven2/com/sun/xml/bind/jaxb-xjc/2.2/jaxb-xjc-2.2.jar"
+touch test_rules.txt
+echo ""
+echo "Running JarJar:"
+java -cp dist/jarjar-1.5.jar org.pantsbuild.jarjar.Main process test_rules.txt corrupt.jar shaded-corrupt.jar
+CODE=$?
+echo ""
+echo "Exit code: $CODE"


### PR DESCRIPTION
Demonstrates the bug described in issue #2.

Output:

```
~/Src/jarjar gmalmquist/jarjar-returncode-lies ./lies.sh
Buildfile: /Users/gmalmquist/Src/jarjar/build.xml

init:
     [echo] bootclasspath

compile:
    [javac] Compiling 1 source file to /Users/gmalmquist/Src/jarjar/build/main
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.5
    [javac] warning: [options] source value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] 4 warnings

jar:
   [jarjar] Building jar: /Users/gmalmquist/Src/jarjar/dist/jarjar-1.5.jar

BUILD SUCCESSFUL
Total time: 1 second
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3028k  100 3028k    0     0  2884k      0  0:00:01  0:00:01 --:--:-- 2887k

Running JarJar:
Syntax error: Duplicate jar entries: com/sun/codemodel/CodeWriter.class

Exit code: 0
```
