### PR TITLE
Make JarJar return a non-zero error-code on hitting duplicates.

### DIFF
--- a/src/main/org/pantsbuild/jarjar/MainUtil.java
+++ b/src/main/org/pantsbuild/jarjar/MainUtil.java
@@ -39,11 +39,11 @@ class MainUtil
                         Throwable cause = e.getCause();
                         if (cause instanceof IllegalArgumentException) {
                             System.err.println("Syntax error: " + cause.getMessage());
-                        } else if (cause instanceof Exception) {
-                            throw (Exception) cause;
-                        } else {
-                            throw e;
                         }
+                        if (cause instanceof Exception) {
+                            throw (Exception) cause;
+                        }
+                        throw e;
                     }
                     return;
                 }

--- a/src/main/org/pantsbuild/jarjar/util/DuplicateJarEntryException.java
+++ b/src/main/org/pantsbuild/jarjar/util/DuplicateJarEntryException.java
@@ -1,0 +1,12 @@
+package org.pantsbuild.jarjar.util;
+
+/**
+ * Raised when a duplicate entry is found in a Jar file being processed.
+ */
+public class DuplicateJarEntryException extends RuntimeException {
+
+  public DuplicateJarEntryException(String jarFile, String name) {
+    super("Duplicate jar entry: " + name + " (in " + jarFile + ")");
+  }
+
+}

--- a/src/main/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
@@ -52,7 +52,7 @@ public class StandaloneJarProcessor
                     } else if (struct.name.endsWith("/")) {
                         // TODO(chrisn): log
                     } else {
-                        throw new IllegalArgumentException("Duplicate jar entries: " + struct.name);
+                        throw new DuplicateJarEntryException(from.getAbsolutePath(), struct.name);
                     }
                 }
             }


### PR DESCRIPTION
Previously duplicate entries discovered by StandaloneJarProcessor
would raise an IllegalArgumentException, which is later converted
to a printed warning rather than an exception for reasons unknown
to me.

To fix this StandaloneJarProcessor now throws a custom exception
type.

This fixes #2 and closes #4.

Output of script from #4 after this change:

```
~/Src/jarjar gmalmquist/error-out-on-duplicate-entry ./lies.sh
Buildfile: /Users/gmalmquist/Src/jarjar/build.xml

init:
     [echo] bootclasspath

compile:
    [javac] Compiling 2 source files to /Users/gmalmquist/Src/jarjar/build/main
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.5
    [javac] warning: [options] source value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] /Users/gmalmquist/Src/jarjar/src/main/org/pantsbuild/jarjar/util/DuplicateJarEntryException.java:6: warning: [serial] serializable class DuplicateJarEntryException has no definition of serialVersionUID
    [javac] public class DuplicateJarEntryException extends RuntimeException {
    [javac]        ^
    [javac] 5 warnings

jar:
   [jarjar] Building jar: /Users/gmalmquist/Src/jarjar/dist/jarjar-1.5.jar

BUILD SUCCESSFUL
Total time: 1 second
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3028k  100 3028k    0     0  3148k      0 --:--:-- --:--:-- --:--:-- 3148k

Running JarJar:
Exception in thread "main" org.pantsbuild.jarjar.ext_util.DuplicateJarEntryException: Duplicate jar entry: com/sun/codemodel/CodeWriter.class (in /Users/gmalmquist/Src/jarjar/corrupt.jar)
        at org.pantsbuild.jarjar.ext_util.StandaloneJarProcessor.run(StandaloneJarProcessor.java:55)
        at org.pantsbuild.jarjar.Main.process(Main.java:94)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.pantsbuild.jarjar.MainUtil.runMain(MainUtil.java:37)
        at org.pantsbuild.jarjar.Main.main(Main.java:50)

Exit code: 1
```
