### PR TITLE
Fixup publishing to target 1.6.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -10,6 +10,9 @@ local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
 read_from = ["%(local_artifact_cache)s"]
 write_to = ["%(local_artifact_cache)s"]
 
+# TODO: Still needed until we migrate jvm tools to subsystems.
+jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+
 
 [goals]
 bootstrap_buildfiles: ['%(buildroot)s/BUILD']
@@ -21,6 +24,19 @@ ivy_settings: %(pants_supportdir)s/ivy/ivysettings.xml
 # We need a custom ivy profile to grab the optional pgp libs for signing artifacts we publish to
 # maven central.
 ivy_profile: %(pants_supportdir)s/ivy/ivy.xml
+
+
+[jvm]
+options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+
+
+[jvm-platform]
+default_platform: java6
+platforms: {
+    'java6': {'source': '6', 'target': '6', 'args': [] },
+    'java7': {'source': '7', 'target': '7', 'args': [] },
+    'java8': {'source': '8', 'target': '8', 'args': [] },
+  }
 
 
 [publish.jar]


### PR DESCRIPTION
This also adds in jvm_options which needs to be set to a non-None
list for JarPublish to function.
