### PR TITLE
Make JarJar handle jars with misplaced classes more reasonably.

### DIFF
--- a/src/main/org/pantsbuild/jarjar/Main.java
+++ b/src/main/org/pantsbuild/jarjar/Main.java
@@ -90,7 +90,8 @@ public class Main {
     List<PatternElement> rules = RulesFileParser.parse(rulesFile);
     boolean verbose = Boolean.getBoolean("verbose");
     boolean skipManifest = Boolean.getBoolean("skipManifest");
-    MainProcessor proc = new MainProcessor(rules, verbose, skipManifest);
+    MainProcessor proc = new MainProcessor(rules, verbose, skipManifest,
+        System.getProperty("misplacedClassStrategy"));
     StandaloneJarProcessor.run(inJar, outJar, proc);
     proc.strip(outJar);
   }

--- a/src/main/org/pantsbuild/jarjar/misplaced/FatalMisplacedClassProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/FatalMisplacedClassProcessor.java
@@ -1,0 +1,28 @@
+package org.pantsbuild.jarjar.misplaced;
+
+import org.pantsbuild.jarjar.util.EntryStruct;
+
+/**
+ * Fails-fast with an exception upon finding a misplaced class.
+ */
+public class FatalMisplacedClassProcessor extends MisplacedClassProcessor {
+
+  @Override public void handleMisplacedClass(EntryStruct classStruct, String className) {
+    throw new FatalMisplacedClassException(formatMisplacedClassMessage(classStruct, className));
+  }
+
+  @Override public boolean shouldTransform() {
+    return false;
+  }
+
+  @Override public boolean shouldKeep() {
+    return false;
+  }
+
+  static class FatalMisplacedClassException extends RuntimeException {
+    FatalMisplacedClassException(String message) {
+      super(message);
+    }
+  }
+
+}

--- a/src/main/org/pantsbuild/jarjar/misplaced/MisplacedClassProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/MisplacedClassProcessor.java
@@ -1,0 +1,64 @@
+package org.pantsbuild.jarjar.misplaced;
+
+import java.io.IOException;
+import org.objectweb.asm.ClassReader;
+import org.pantsbuild.jarjar.util.EntryStruct;
+import org.pantsbuild.jarjar.util.JarProcessor;
+
+/**
+ * Processor that handles classes whose fully-qualified names do not match their jar entry location.
+ */
+public abstract class MisplacedClassProcessor implements JarProcessor {
+
+  /**
+   * Handles a class that was found at a location that does not match its fully qualified classname.
+   * @param classStruct The jar EntryStruct for the class.
+   * @param className The actual fully-qualified classname read from the binary data.
+   */
+  public abstract void handleMisplacedClass(EntryStruct classStruct, String className);
+
+  /**
+   * Whether any JarTransformers transform and relocate the struct to its "proper" location based on
+   * its package name, or just skip over it.
+   * @return True if the struct should be transformed, false otherwise.
+   */
+  public abstract boolean shouldTransform();
+
+  /**
+   * Returns whether the entry should be included in the output.
+   * @return true if it should be kept, false if it should be omitted.
+   */
+  public abstract boolean shouldKeep();
+
+  @Override public boolean process(EntryStruct struct)
+      throws IOException {
+    if (!struct.name.endsWith(".class")) return true;
+
+    String originalClassName;
+    try {
+      originalClassName = new ClassReader(struct.data).getClassName() + ".class";
+    } catch (Exception e) {
+      System.err.println("Unable to read classname from bytecode in " + struct.name);
+      System.err.println("Shading is therefore impossible, so this entry will be skipped.");
+      System.err.println(e.getClass().getName() + ": " + e.getMessage());
+      struct.skipTransform = true;
+      return true;
+    }
+    if (!originalClassName.equals(struct.name)) {
+      System.err.println(formatMisplacedClassMessage(struct, originalClassName));
+      handleMisplacedClass(struct, originalClassName);
+      if (!shouldTransform()) {
+        struct.skipTransform = true;
+      }
+      return shouldKeep();
+    }
+    return true;
+  }
+
+  protected String formatMisplacedClassMessage(EntryStruct classStruct, String className) {
+    return "Fully-qualified classname does not match jar entry:\n"
+        + "  jar entry: " + classStruct.name + "\n"
+        + "  class name: " + className;
+  }
+
+}

--- a/src/main/org/pantsbuild/jarjar/misplaced/MisplacedClassProcessorFactory.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/MisplacedClassProcessorFactory.java
@@ -1,0 +1,68 @@
+package org.pantsbuild.jarjar.misplaced;
+
+/**
+ * Factory singleton for creating a MisplacedProcessorFactory from a user-level strategy string.
+ */
+public class MisplacedClassProcessorFactory {
+
+  public enum Strategy {
+    /** Strategy which fails-fast with an exception upon hitting misplaced class. */
+    FATAL,
+
+    /** Strategy which skips past misplaced classes, excluding them from shading. */
+    SKIP,
+
+    /** Strategy which omits misplaced classes from the output. */
+    OMIT,
+
+    /**
+     * Strategy which renames misplaced classes to their "proper" location based on their
+     * fully-qualified class name.
+     */
+    MOVE,
+  };
+
+  private static MisplacedClassProcessorFactory me;
+
+  public static synchronized MisplacedClassProcessorFactory getInstance() {
+    if (me == null) {
+      me = new MisplacedClassProcessorFactory();
+    }
+    return me;
+  }
+
+  private MisplacedClassProcessorFactory() {}
+
+  /**
+   * Returns the default misplaced class processor, which is "omit".
+   *
+   * @return
+   */
+  public MisplacedClassProcessor getDefaultProcessor() {
+    return new OmitMisplacedClassProcessor();
+  }
+
+  /**
+   * Creates a MisplacedClassProcessor according for the given strategy name.
+   *
+   * @param name The case-insensitive user-level strategy name (see the STRATEGY_* constants).
+   * @return The MisplacedClassProcessor corresponding to the strategy name, or the result of
+   * getDefaultProcessor() if name is null.
+   * @throws IllegalAccessException if an unrecognized non-null strategy name is specified.
+   */
+  public MisplacedClassProcessor getProcessorForName(String name) {
+    if (name == null) {
+      return getDefaultProcessor();
+    }
+
+    switch (Strategy.valueOf(name.toUpperCase())) {
+      case FATAL: return new FatalMisplacedClassProcessor();
+      case MOVE: return new MoveMisplacedClassProcessor();
+      case OMIT: return new OmitMisplacedClassProcessor();
+      case SKIP: return new SkipMisplacedClassProcessor();
+    }
+
+    throw new IllegalArgumentException("Unrecognized strategy name \"" + name + "\".");
+  }
+
+}

--- a/src/main/org/pantsbuild/jarjar/misplaced/MoveMisplacedClassProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/MoveMisplacedClassProcessor.java
@@ -1,0 +1,22 @@
+package org.pantsbuild.jarjar.misplaced;
+
+import org.pantsbuild.jarjar.util.EntryStruct;
+
+/**
+ * Moves misplaced classes to their proper location based on their package name.
+ */
+public class MoveMisplacedClassProcessor extends MisplacedClassProcessor {
+
+  @Override public void handleMisplacedClass(EntryStruct classStruct, String className) {
+    System.err.println("Renaming " + classStruct.name + " to " + className);
+  }
+
+  @Override public boolean shouldTransform() {
+    return true;
+  }
+
+  @Override public boolean shouldKeep() {
+    return true;
+  }
+
+}

--- a/src/main/org/pantsbuild/jarjar/misplaced/OmitMisplacedClassProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/OmitMisplacedClassProcessor.java
@@ -1,0 +1,21 @@
+package org.pantsbuild.jarjar.misplaced;
+
+import org.pantsbuild.jarjar.util.EntryStruct;
+
+/**
+ * Leave misplaced classes out of the jar.
+ */
+public class OmitMisplacedClassProcessor extends MisplacedClassProcessor {
+
+  @Override public void handleMisplacedClass(EntryStruct classStruct, String className) {
+    System.err.println("Omitting " + classStruct.name + ".");
+  }
+
+  @Override public boolean shouldTransform() {
+    return false;
+  }
+
+  @Override public boolean shouldKeep() {
+    return false;
+  }
+}

--- a/src/main/org/pantsbuild/jarjar/misplaced/SkipMisplacedClassProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/misplaced/SkipMisplacedClassProcessor.java
@@ -1,0 +1,22 @@
+package org.pantsbuild.jarjar.misplaced;
+
+import org.pantsbuild.jarjar.util.EntryStruct;
+
+/**
+ * Handles misplaced classes by excluding them from shading
+ * (which leaves them at their original location).
+ */
+public class SkipMisplacedClassProcessor extends MisplacedClassProcessor {
+
+  @Override public void handleMisplacedClass(EntryStruct classStruct, String className) {
+    System.err.println("Skipping shading of " + classStruct.name);
+  }
+
+  @Override public boolean shouldTransform() {
+    return false;
+  }
+
+  @Override public boolean shouldKeep() {
+    return true;
+  }
+}

--- a/src/main/org/pantsbuild/jarjar/util/EntryStruct.java
+++ b/src/main/org/pantsbuild/jarjar/util/EntryStruct.java
@@ -16,12 +16,9 @@
 
 package org.pantsbuild.jarjar.util;
 
-import java.io.InputStream;
-import java.io.File;
-
-public class EntryStruct
-{
+public class EntryStruct {
     public byte[] data;
     public String name;
     public long time;
+    public boolean skipTransform;
 }

--- a/src/main/org/pantsbuild/jarjar/util/JarProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/util/JarProcessor.java
@@ -23,12 +23,13 @@ public interface JarProcessor
     /**
      * Process the entry (p.ex. rename the file)
      * <p>
-     * Returns <code>true</code> if the processor has has changed the entry. In this case, the entry can be removed
-     * from the jar file in a future time. Return <code>false</code> for the entries which do not have been changed and
-     * there fore are not to be deleted
+     * Returns <code>true</code> if the processor "successfully" processed the entry. In practice,
+     * "true" is used to indicate that the entry should be kept, and false is used to indicate the
+     * entry should be thrown away, and doesn't indicate anything in particular about what this
+     * JarProcessor actually did to the entry (if anything).
      *
-     * @param struct
-     * @return <code>true</code> if he process chain can continue after this process
+     * @param struct The jar entry.
+     * @return <code>true</code> if the process chain can continue after this process
      * @throws IOException
      */
     boolean process(EntryStruct struct) throws IOException;

--- a/src/main/org/pantsbuild/jarjar/util/JarProcessorChain.java
+++ b/src/main/org/pantsbuild/jarjar/util/JarProcessorChain.java
@@ -32,13 +32,10 @@ public class JarProcessorChain implements JarProcessor
      * @return <code>true</code> if the entry has run the complete chain
      * @throws IOException
      */
-    public boolean process(EntryStruct struct) throws IOException
-    {
+    public boolean process(EntryStruct struct) throws IOException {
 
-        for (JarProcessor aChain : chain)
-        {
-            if (!aChain.process(struct))
-            {
+        for (JarProcessor processor : chain) {
+            if (!processor.process(struct)) {
                 return false;
             }
         }

--- a/src/main/org/pantsbuild/jarjar/util/JarTransformer.java
+++ b/src/main/org/pantsbuild/jarjar/util/JarTransformer.java
@@ -21,16 +21,19 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
-abstract public class JarTransformer implements JarProcessor
-{
+abstract public class JarTransformer implements JarProcessor {
+
     public boolean process(EntryStruct struct) throws IOException {
-        if (struct.name.endsWith(".class")) {
+        if (struct.name.endsWith(".class") && !struct.skipTransform) {
             ClassReader reader;
             try {
                 reader = new ClassReader(struct.data);
             } catch (Exception e) {
-                return true; // TODO?
+                System.err.println("Unable to read bytecode from " + struct.name);
+                e.printStackTrace();
+                return true;
             }
+
             GetNameClassWriter w = new GetNameClassWriter(ClassWriter.COMPUTE_MAXS);
             reader.accept(transform(w), ClassReader.EXPAND_FRAMES);
             struct.data = w.toByteArray();

--- a/src/main/org/pantsbuild/jarjar/util/JarTransformerChain.java
+++ b/src/main/org/pantsbuild/jarjar/util/JarTransformerChain.java
@@ -21,7 +21,7 @@ import org.objectweb.asm.ClassVisitor;
 public class JarTransformerChain extends JarTransformer
 {
     private final RemappingClassTransformer[] chain;
-    
+
     public JarTransformerChain(RemappingClassTransformer[] chain) {
         this.chain = chain.clone();
         for (int i = chain.length - 1; i > 0; i--) {

--- a/src/test/org/pantsbuild/jarjar/integration/BadPackagesTest.java
+++ b/src/test/org/pantsbuild/jarjar/integration/BadPackagesTest.java
@@ -1,0 +1,187 @@
+package org.pantsbuild.jarjar.integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import junit.framework.AssertionFailedError;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * These tests exercise JarJar's behavior when it processes classes whose jar entries do not match
+ * their fully-qualified class names (ie when classes are in the "wrong" directory).
+ */
+public class BadPackagesTest extends IntegrationTestBase {
+
+  @Test
+  public void testSkipMisnamedClass() throws Exception {
+    File jar = createJarWithMisnamedClass();
+
+    jar = shadeJar(jar, new HashMap<String, String>() {{
+      put("verbose", "true");
+      put("misplacedClassStrategy", "skip");
+    }}, null);
+
+    List<String> entries = getJarEntries(jar);
+    Assert.assertTrue(entries.contains("Misnamed.class"));
+    assertFalse(entries.contains("org/pantsbuild.jarjar/fake/Foobar.class"));
+    assertTrue(entries.contains("README.md"));
+  }
+
+  @Test
+  public void testMoveMisnamedClass() throws Exception {
+    File jar = createJarWithMisnamedClass();
+
+    jar = shadeJar(jar, new HashMap<String, String>() {{
+      put("verbose", "true");
+      put("misplacedClassStrategy", "move");
+    }}, null);
+
+    List<String> entries = getJarEntries(jar);
+    assertFalse(entries.contains("Misnamed.class"));
+    Assert.assertTrue(entries.contains("org/pantsbuild/jarjar/fake/Foobar.class"));
+    assertTrue(entries.contains("README.md"));
+  }
+
+  @Test
+  public void testOmitMisnamedClass() throws Exception {
+    File jar = createJarWithMisnamedClass();
+
+    jar = shadeJar(jar, new HashMap<String, String>() {{
+      put("verbose", "true");
+      put("misplacedClassStrategy", "omit");
+    }}, null);
+
+    List<String> entries = getJarEntries(jar);
+    assertFalse(entries.contains("Misnamed.class"));
+    Assert.assertFalse(entries.contains("org/pantsbuild/jarjar/fake/Foobar.class"));
+    assertTrue(entries.contains("README.md"));
+  }
+
+  @Test
+  public void testFatalMisnamedClass() throws Exception {
+    File jar = createJarWithMisnamedClass();
+
+    boolean failed = false;
+    try {
+      jar = shadeJar(jar, new HashMap<String, String>() {{
+        put("verbose", "true");
+        put("misplacedClassStrategy", "fatal");
+      }}, null);
+    } catch (JarJarFailedException e) {
+      failed = true;
+      Assert.assertTrue(e.getMessage().contains("Fully-qualified classname does not match jar entry"));
+    }
+    Assert.assertTrue("Jar jar should have failed, but didn't!", failed);
+
+    List<String> entries = getJarEntries(jar);
+    Assert.assertTrue(entries.contains("Misnamed.class"));
+    assertFalse(entries.contains("org/pantsbuild.jarjar/fake/Foobar.class"));
+    assertTrue(entries.contains("README.md"));
+  }
+
+  private File createJarWithMisnamedClass() throws Exception {
+    String className = "org.pantsbuild.jarjar.fake.Foobar";
+    String basePath = className.replaceAll("[.]", "/");
+    String sourcePath = basePath + ".java";
+    String binaryPath = basePath + ".class";
+
+    Map<String, String> files = new HashMap<String, String>();
+    files.put(sourcePath, basicJavaFile(className));
+    files.put("README.md", "# Just making sure that normal resource files still work fine.");
+
+    File folder = createTree(files);
+    Assert.assertTrue(tryCompile(folder, "-source", "6", "-target", "6", sourcePath));
+
+    File srcFile = new File(folder + File.separator + binaryPath);
+    File dstFile = new File(folder + File.separator + "Misnamed.class");
+    dstFile.getParentFile().mkdirs();
+    srcFile.renameTo(dstFile);
+
+    for (String file : new FileTree(folder)) {
+      if (file.endsWith(".java")) {
+        new File(folder.getAbsolutePath() + File.separator + file).delete();
+      }
+    }
+
+    return createJar(folder);
+  }
+
+  /**
+   * Creates a jar file with a single class, compiled in java 6.
+   *
+   * A duplicate version of the class is created in a "oldversion" directory, and included
+   * in the same jar.
+   *
+   * This targets a bug where jarjar would move classes which are not in a folder according to their
+   * package name BACK into the appropriate folder, which can potentially cause
+   * DuplicateJarEntryExcetions, in the very specific case where two versions of a class exist in
+   * the same jar, with one version stored in a separate directory.
+   *
+   * In general, this situation should never happen and is reflective of corrupted jars, but
+   * unfortunately there are some examples of these jars in the wild
+   * (eg http://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-xjc/2.2). These can get pulled in
+   * as transitive dependencies when folks use lots of opensource software without them even
+   * knowing, causing jar shading to explode.
+   *
+   * @return
+   * @throws IOException
+   */
+  private File createJarWithOldVersion() throws IOException {
+    String className = "org.pantsbuild.jarjar.fake.Foobar";
+    String basePath = className.replaceAll("[.]", "/");
+    String sourcePath = basePath + ".java";
+    String binaryPath = basePath + ".class";
+
+    Map<String, String> files = new HashMap<String, String>();
+    files.put(sourcePath, basicJavaFile(className));
+
+    File folder = createTree(files);
+    Assert.assertTrue(tryCompile(folder, "-source", "6", "-target", "6", sourcePath));
+
+    File srcFile = new File(folder + File.separator + binaryPath);
+    File dstFile = new File(folder + File.separator + "oldversion" + File.separator + binaryPath);
+    dstFile.getParentFile().mkdirs();
+    srcFile.renameTo(dstFile);
+
+    Assert.assertTrue(tryCompile(folder, "-source", "6", "-target", "6", sourcePath));
+
+    for (String file : new FileTree(folder)) {
+      if (file.endsWith(".java")) {
+        new File(folder.getAbsolutePath() + File.separator + file).delete();
+      }
+    }
+
+    return createJar(folder);
+  }
+
+  @Test
+  public void testJarWithOldVersionsPackage() throws Exception {
+    try {
+      File jar = createJarWithOldVersion();
+      List<String> entries = getJarEntries(jar);
+      Assert.assertTrue("Unshaded jar does not have new version of Foobar.",
+          entries.contains("org/pantsbuild/jarjar/fake/Foobar.class"));
+      Assert.assertTrue("Unshaded jar does not have old version of Foobar.",
+          entries.contains("oldversion/org/pantsbuild/jarjar/fake/Foobar.class"));
+
+      File shadedJar = shadeJar(jar, new HashMap<String, String>() {{
+        put("verbose", "true");
+        put("misplacedClassStrategy", "skip");
+      }}, null);
+      entries = getJarEntries(shadedJar);
+      Assert.assertTrue("Shaded jar does not have new version of Foobar.",
+          entries.contains("org/pantsbuild/jarjar/fake/Foobar.class"));
+      Assert.assertTrue("Shaded jar does not have old version of Foobar.",
+          entries.contains("oldversion/org/pantsbuild/jarjar/fake/Foobar.class"));
+    } catch (AssertionFailedError e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+}

--- a/src/test/org/pantsbuild/jarjar/integration/FileTree.java
+++ b/src/test/org/pantsbuild/jarjar/integration/FileTree.java
@@ -1,0 +1,70 @@
+package org.pantsbuild.jarjar.integration;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Stack;
+
+/**
+ * Iterator over a file tree.
+ *
+ * Roughly correlates to python's os.walk.
+ */
+public class FileTree implements Iterable<String> {
+
+  private File root;
+
+  /**
+   * Creates a new recursive iterator over a directory.
+   *
+   * @param root The root directory to iterate over.
+   */
+  public FileTree(File root) {
+    this.root = root;
+  }
+
+  public File getRoot() {
+    return root;
+  }
+
+  public Iterator<String> iterator() {
+    return new FileTreeIterator();
+  }
+
+  class FileTreeIterator implements Iterator<String> {
+
+    private Stack<String> fileStack;
+
+    public FileTreeIterator() {
+      fileStack = new Stack<String>();
+      expand("");
+    }
+
+    private void expand(String path) {
+      File file = new File(root + File.separator + path);
+      if (file.isDirectory()) {
+        for (File f : file.listFiles()) {
+          if (path.length() > 0) {
+            fileStack.push(path + File.separator + f.getName());
+          } else {
+            fileStack.push(f.getName());
+          }
+        }
+      }
+    }
+
+    @Override public boolean hasNext() {
+      return !fileStack.isEmpty();
+    }
+
+    @Override public String next() {
+      String nextPath = fileStack.pop();
+      expand(nextPath);
+      return nextPath;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("Remove not implemented.");
+    }
+  }
+}

--- a/src/test/org/pantsbuild/jarjar/integration/IntegrationTestBase.java
+++ b/src/test/org/pantsbuild/jarjar/integration/IntegrationTestBase.java
@@ -1,0 +1,262 @@
+package org.pantsbuild.jarjar.integration;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Base class for jarjar integration tests. Provides common utilities.
+ */
+public abstract class IntegrationTestBase extends TestCase {
+
+  @org.junit.Rule
+  public TemporaryFolder workdir = new TemporaryFolder();
+
+  private File jarjarBinary;
+
+  protected File getJarJarBinary() throws IOException, InterruptedException {
+    if (jarjarBinary != null) return jarjarBinary;
+    File binary = new File("dist" + File.separator + "jarjar.jar");
+    if (binary.exists()) {
+      binary.delete();
+    }
+    Runtime.getRuntime().exec(new String[] {
+        "./pants", "--no-lock", "binary", "src/main::",
+    }).waitFor();
+    jarjarBinary = binary;
+    return binary;
+  }
+
+  /**
+   * Invokes javac in the given working directory with the given arguments.
+   * @param directory The working directory to run javac in.
+   * @param args The varargs list of arguments to javac.
+   * @return true if javac succeeds, false otherwise.
+   */
+  protected boolean tryCompile(File directory, String ... args) {
+    List<String> javacArgs = new LinkedList<String>();
+    javacArgs.add("javac");
+
+    for (String arg : args) {
+      javacArgs.add(arg);
+    }
+
+    String[] cmd = javacArgs.toArray(new String[javacArgs.size()]);
+
+    try {
+      Process p = Runtime.getRuntime().exec(cmd, null, directory);
+      ProcessCommunicator cp = new ProcessCommunicator(p);
+      int result = cp.communicate();
+      System.out.println(cp.getStdoutText());
+      System.out.println(cp.getStderrText());
+      return result == 0;
+    } catch (IOException e) {
+      return false;
+    } catch (InterruptedException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns the list of file entires in a jar file.
+   * @param jarFile The jar file to list.
+   * @return the List of entries.
+   */
+  protected List<String> getJarEntries(File jarFile) {
+    String[] cmd = {"jar", "-tf", jarFile.getAbsolutePath()};
+    try {
+      List<String> lines = new LinkedList<String>();
+      Process p = Runtime.getRuntime().exec(cmd);
+      BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+      while (true) {
+        try {
+          String line = in.readLine();
+          if (line == null) break;
+          lines.add(line);
+        } catch (IOException e) {
+          break;
+        }
+      }
+
+      p.waitFor();
+      assertEquals(0, p.exitValue());
+      return lines;
+    } catch (IOException e) {
+      return null;
+    } catch (InterruptedException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Creates a new temporary folder with one file for each key in the map.
+   *
+   * The values for each key are written to the contents of each file.
+   *
+   * @param filenamesToContents A map of (relative path name) -> (contents of file).
+   * @return the temporary directory file object.
+   */
+  protected File createTree(Map<String, String> filenamesToContents) throws IOException {
+    File tempdir = workdir.newFolder();
+
+    for (String filename : filenamesToContents.keySet()) {
+      File file = new File(tempdir.getAbsolutePath() + File.separator + filename);
+      if (!file.getParentFile().exists()) {
+        file.getParentFile().mkdirs();
+      }
+      PrintStream out = new PrintStream(file);
+      out.println(filenamesToContents.get(filename));
+      out.close();
+    }
+
+    return tempdir;
+  }
+
+  /**
+   * Creates a new jar file by zipping up the given folder.
+   *
+   * @param folder The folder to zip up.
+   * @param manifestEntries Lines to write to the manifest file (optional).
+   * @return The jar file.
+   */
+  protected File createJar(File folder, String ... manifestEntries) throws IOException {
+    File outputJar = workdir.newFile();
+    File manifestFile = workdir.newFile();
+
+    PrintStream manifestOut = new PrintStream(manifestFile);
+    for (String line : manifestEntries) {
+      manifestOut.println(line);
+    }
+
+    List<String> jarargs = new LinkedList<String>();
+    jarargs.add("jar");
+    jarargs.add("-cfm");
+    jarargs.add(outputJar.getAbsolutePath());
+    jarargs.add(manifestFile.getAbsolutePath());
+
+    List<String> filesToJar = new LinkedList<String>();
+    for (String relativePath : new FileTree(folder)) {
+      filesToJar.add(relativePath);
+    }
+
+    Collections.sort(filesToJar, new Comparator<String>() {
+      @Override public int compare(String a, String b) {
+        return a.compareTo(b);
+      }
+    });
+    jarargs.addAll(filesToJar);
+
+    String[] cmd = jarargs.toArray(new String[jarargs.size()]);
+
+    Process p = Runtime.getRuntime().exec(cmd, null, folder);
+    try {
+      p.waitFor();
+    } catch (InterruptedException e) {
+    }
+
+    assertEquals(0, p.exitValue());
+    assertTrue(outputJar.exists());
+
+    return outputJar;
+  }
+
+  /**
+   * Invokes jarjar to shade the jarfile with the given rules.
+   *
+   * @param jarFile The jarFile to shade.
+   * @param jarjarArgs Optional map of arguments for jarjar.
+   * @param rules Optional list of shading rules for jarjar.
+   * @return The output shaded jar.
+   */
+  protected File shadeJar(File jarFile, Map<String, String> jarjarArgs, String[] rules) throws Exception {
+    File rulesFile = workdir.newFile();
+    PrintStream out = new PrintStream(rulesFile);
+    if (rules != null) {
+      for (String rule : rules) {
+        out.println(rule);
+      }
+    }
+    out.close();
+
+    File outFile = workdir.newFile();
+
+    List<String> args = new ArrayList<String>();
+    args.add("java");
+
+    if (jarjarArgs != null) {
+      for (String key : jarjarArgs.keySet()) {
+        args.add("-D" + key + "=" + jarjarArgs.get(key));
+      }
+    }
+
+    String[] typicalArgs = {
+        "-cp", getJarJarBinary().getAbsolutePath(),
+        "org.pantsbuild.jarjar.Main",
+        "process",
+        rulesFile.getAbsolutePath(),
+        jarFile.getAbsolutePath(),
+        outFile.getAbsolutePath()
+    };
+    for (String arg : typicalArgs) {
+      args.add(arg);
+    }
+
+    Process p = Runtime.getRuntime().exec(args.toArray(new String[args.size()]));
+
+    ProcessCommunicator pc = new ProcessCommunicator(p);
+    int result = pc.communicate();
+    if (result != 0) {
+      throw new JarJarFailedException(pc);
+    }
+    return outFile;
+  }
+
+  /**
+   * Generates the contents of a syntactically correct but useless java file.
+   *
+   * Just includes a package definition and an empty class body.
+   *
+   * @param fullyQualifiedName The fully qualified classname of the java class should use.
+   */
+  protected String basicJavaFile(String fullyQualifiedName) {
+    fullyQualifiedName = fullyQualifiedName.replaceAll("[.]", File.separator);
+
+    String packageName = null;
+    String className = null;
+
+    int slash = fullyQualifiedName.lastIndexOf('/');
+    if (slash < 0) {
+      className = fullyQualifiedName;
+    } else {
+      packageName = fullyQualifiedName.substring(0, slash).replaceAll(File.separator, ".");
+      className = fullyQualifiedName.substring(slash+1);
+    }
+
+    StringBuffer sb = new StringBuffer(fullyQualifiedName.length()*2);
+    if (packageName != null) {
+      sb.append("package ");
+      sb.append(packageName);
+      sb.append(";\n\n");
+    }
+    sb.append("public class ");
+    sb.append(className);
+    sb.append(" { /* NOTHING TO SEE HERE */ }\n");
+
+    return sb.toString();
+  }
+
+}

--- a/src/test/org/pantsbuild/jarjar/integration/JarJarFailedException.java
+++ b/src/test/org/pantsbuild/jarjar/integration/JarJarFailedException.java
@@ -1,0 +1,7 @@
+package org.pantsbuild.jarjar.integration;
+
+public class JarJarFailedException extends RuntimeException {
+  public JarJarFailedException(ProcessCommunicator pc) {
+    super("JarJar did not exit successfully: " + pc.getStderrText());
+  }
+}

--- a/src/test/org/pantsbuild/jarjar/integration/ProcessCommunicator.java
+++ b/src/test/org/pantsbuild/jarjar/integration/ProcessCommunicator.java
@@ -1,0 +1,99 @@
+package org.pantsbuild.jarjar.integration;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Slurps the input/output streams of a Process.
+ */
+public class ProcessCommunicator {
+
+  private Process process;
+  private List<String> stderr;
+  private List<String> stdout;
+
+  public ProcessCommunicator(Process p) {
+    this.process = p;
+    this.stderr = new LinkedList<String>();
+    this.stdout = new LinkedList<String>();
+  }
+
+  /**
+   * Waits for the process to finish, and returns its returncode.
+   *
+   * @return The integer return code (exitValue()) of the process.
+   * @throws InterruptedException
+   */
+  public int communicate() throws InterruptedException {
+    slurpStream(process.getInputStream(), stdout);
+    slurpStream(process.getErrorStream(), stderr);
+    process.waitFor();
+    return process.exitValue();
+  }
+
+  /**
+   * Gets the lines of standard error.
+   * @return a list of error lines.
+   */
+  public List<String> getStderrLines() {
+    return stderr;
+  }
+
+  /**
+   * Gets the lines of standard output.
+   * @return a list of error lines.
+   */
+  public List<String> getStdoutLines() {
+    return stdout;
+  }
+
+  /**
+   * Gets the standard output as a single string.
+   * @return the stdout text.
+   */
+  public String getStdoutText() {
+    return toBlob(stdout);
+  }
+
+  /**
+   * Gets the standard error as a single string.
+   * @return the stderr text.
+   */
+  public String getStderrText() {
+    return toBlob(stderr);
+  }
+
+  private String toBlob(List<String> lines) {
+    StringBuffer sb = new StringBuffer(10*lines.size());
+    for (String s : lines) {
+      if (sb.length() > 0) {
+        sb.append("\n");
+      }
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+
+  private void slurpStream(InputStream sin, final List<String> list) {
+    final BufferedReader in = new BufferedReader(new InputStreamReader(sin));
+    new Thread(new Runnable() {
+      public void run() {
+        while (true) {
+          try {
+            String line = in.readLine();
+            if (line == null)
+              break;
+            list.add(line);
+          } catch (IOException e) {
+            break;
+          }
+        }
+      }
+    }).start();
+  }
+
+}


### PR DESCRIPTION
A "misplaced class" here refers to a class whose jar entry path
(eg, "org/pantsbuild/Foobar.class") does not match the path
implied by its fully-qualified classname.

Previously, if you had a (corrupt) jar with a directory containing
misplaced classes, jarjar would move all the classes in the so
that their directory properly matched their package names. This
was simply an undocumented (and probably unconsidered) side-effect
of how jar entries are transformed by the JarTransformer.

This would cause problems when there already were classes at those
locations, and JarJar would explode due to a duplicate jar entries
problem that it had constructed itself.

With this change, JarJar allows the specification of a
"misnamedClassStrategy" variable, which can be "fatal" (for
fail-fast exit behavior), "move" (for the previously existing
behavior), or "skip" (exclude the classes from shading).

This defaults to "skip". A warning is also printed to stderr if the
verbose flag is turned on.
