### PR TITLE
Buffer jar writes.  

### DIFF
--- a/src/main/org/pantsbuild/jarjar/util/IoUtil.java
+++ b/src/main/org/pantsbuild/jarjar/util/IoUtil.java
@@ -62,7 +62,9 @@ class IoUtil {
         final byte[] buf = new byte[0x2000];
 
         final ZipFile inputZip = new ZipFile(inputFile);
-        final ZipOutputStream outputStream = new ZipOutputStream(new FileOutputStream(outputFile));
+        BufferedOutputStream buffered = new BufferedOutputStream(new FileOutputStream(outputFile));
+
+        final ZipOutputStream outputStream = new ZipOutputStream(buffered);
         try
         {
             // read a the entries of the input zip file and sort them

--- a/src/main/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
+++ b/src/main/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
@@ -30,7 +30,8 @@ public class StandaloneJarProcessor
 
         JarFile in = new JarFile(from);
         final File tmpTo = File.createTempFile("jarjar", ".jar");
-        JarOutputStream out = new JarOutputStream(new FileOutputStream(tmpTo));
+        BufferedOutputStream buffered = new BufferedOutputStream(new FileOutputStream(tmpTo));
+        JarOutputStream out = new JarOutputStream(buffered);
         Set<String> entries = new HashSet<String>();
         try {
             EntryStruct struct = new EntryStruct();


### PR DESCRIPTION
This should be much faster on large jars (especially on fuse filesystems).
