### PR TITLE
Shade entries that come after a misnamed class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.pants.d/
 /dist/
 /.pids/
+/.cache/
 
 # IDEA project definition files
 *.iml

--- a/src/main/java/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
+++ b/src/main/java/org/pantsbuild/jarjar/util/StandaloneJarProcessor.java
@@ -34,9 +34,9 @@ public class StandaloneJarProcessor
         JarOutputStream out = new JarOutputStream(buffered);
         Set<String> entries = new HashSet<String>();
         try {
-            EntryStruct struct = new EntryStruct();
             Enumeration<JarEntry> e = in.entries();
             while (e.hasMoreElements()) {
+                EntryStruct struct = new EntryStruct();
                 JarEntry entry = e.nextElement();
                 struct.name = entry.getName();
                 struct.time = entry.getTime();


### PR DESCRIPTION
A developer noticed that pants's shading was omitting some shaded
classes from a shaded hadoop fatjar, seemingly arbitrarily. After
much investigation, he discovered that jarjar was simply skipping
shading for all entries that followed a single misnamed class, and
the fatjar included `1.0/...` entries that were being omitted.

The fix is extremely simple, just moving a single line of code.

Testing done:

Added a couple test-cases to BadPackagesTest, confirmed that they
work with this change, and break without it.
