### PR TITLE
Update API version in visitors to ASM5

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
+++ b/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
@@ -28,23 +28,23 @@ import org.objectweb.asm.Opcodes;
 public class EmptyClassVisitor extends ClassVisitor {
 
     public EmptyClassVisitor() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
-    
+
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        return new MethodVisitor(Opcodes.ASM4) {};
+        return new MethodVisitor(Opcodes.ASM5) {};
     }
-    
+
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM4) {};
+        return new AnnotationVisitor(Opcodes.ASM5) {};
     }
-    
+
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-        return new FieldVisitor(Opcodes.ASM4) {};
+        return new FieldVisitor(Opcodes.ASM5) {};
     }
 
 }

--- a/src/main/java/org/pantsbuild/jarjar/StringReader.java
+++ b/src/main/java/org/pantsbuild/jarjar/StringReader.java
@@ -24,16 +24,16 @@ abstract class StringReader extends ClassVisitor
     private String className;
 
     public StringReader() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
-    
+
     abstract public void visitString(String className, String value, int line);
 
     private void handleObject(Object value) {
         if (value instanceof String)
             visitString(className, (String)value, line);
     }
-    
+
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         className = name;
@@ -42,17 +42,17 @@ abstract class StringReader extends ClassVisitor
 
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         handleObject(value);
-        return new FieldVisitor(Opcodes.ASM4){
+        return new FieldVisitor(Opcodes.ASM5){
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 return StringReader.this.visitAnnotation(desc, visible);
             }
         };
     }
-    
+
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM4) {
+        return new AnnotationVisitor(Opcodes.ASM5) {
             @Override
             public void visit(String name, Object value) {
                 handleObject(value);
@@ -67,11 +67,11 @@ abstract class StringReader extends ClassVisitor
             }
         };
     }
-    
+
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        MethodVisitor mv = new MethodVisitor(Opcodes.ASM4){
+        MethodVisitor mv = new MethodVisitor(Opcodes.ASM5){
             @Override
             public void visitLdcInsn(Object cst) {
                 handleObject(cst);

--- a/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
+++ b/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
@@ -23,20 +23,20 @@ import org.objectweb.asm.Opcodes;
 public class GetNameClassWriter extends ClassVisitor
 {
     private String className;
-    
+
     public GetNameClassWriter(int flags) {
-        super(Opcodes.ASM4,new ClassWriter(flags));
+        super(Opcodes.ASM5,new ClassWriter(flags));
     }
 
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         className = name;
         super.visit(version, access, name, signature, superName, interfaces);
     }
-    
+
     public String getClassName() {
         return className;
     }
-    
+
     public byte[] toByteArray() {
         return ((ClassWriter) cv).toByteArray();
     }


### PR DESCRIPTION
We are using "org.pantsbuild" % "jarjar" % "1.6.0" in the SBT
build for Scala.

We see an error when we call JarJar with bytecode that contains
the `MethodParameters` attribute.

This seems to be due to the fact that you updated to ASM5, but
did not update all visitors in this project to the ASM5 api
version.

The ASM5's `ClassReader` visits these parameters, ultimately
with `EmptyClassVisitor`, which runs into:

``` java
    public void visitParameter(String name, int access) {
        if (api < Opcodes.ASM5) {
            throw new RuntimeException();
        }
        if (mv != null) {
            mv.visitParameter(name, access);
        }
    }
```

See:

  https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html

for discussion of the `MethodParameters` classfile attribute. It is
not enabled by default, one needs to enable it with:

```
javac -help 2>&1 | grep parameters
  -parameters                Generate metadata for reflection on method parameters
```

No test is included here as I'm not familiar with pants to know how to
add this.
