### PR TITLE
Update to ASM5 API version

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
+++ b/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
@@ -28,23 +28,23 @@ import org.objectweb.asm.Opcodes;
 public class EmptyClassVisitor extends ClassVisitor {
 
     public EmptyClassVisitor() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
-    
+
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        return new MethodVisitor(Opcodes.ASM4) {};
+        return new MethodVisitor(Opcodes.ASM5) {};
     }
-    
+
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM4) {};
+        return new AnnotationVisitor(Opcodes.ASM5) {};
     }
-    
+
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-        return new FieldVisitor(Opcodes.ASM4) {};
+        return new FieldVisitor(Opcodes.ASM5) {};
     }
 
 }

--- a/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
+++ b/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
@@ -30,7 +30,7 @@ class KeepProcessor extends Remapper implements JarProcessor
     private final List<Wildcard> wildcards;
     private final List<String> roots = new ArrayList<String>();
     private final Map<String, Set<String>> depend = new HashMap<String, Set<String>>();
-    
+
     public KeepProcessor(List<Keep> patterns) {
         wildcards = PatternElement.createWildcards(patterns);
     }
@@ -72,7 +72,8 @@ class KeepProcessor extends Remapper implements JarProcessor
                 curSet.remove(name);
             }
         } catch (Exception e) {
-          System.err.println("Error reading " + struct.name + ": " + e.getMessage());
+            System.err.println("Error reading " + struct.name + ": " + e.getMessage());
+            System.exit(-1);
         }
         return true;
     }

--- a/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
+++ b/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
@@ -73,7 +73,6 @@ class KeepProcessor extends Remapper implements JarProcessor
             }
         } catch (Exception e) {
             System.err.println("Error reading " + struct.name + ": " + e.getMessage());
-            System.exit(-1);
         }
         return true;
     }

--- a/src/main/java/org/pantsbuild/jarjar/StringReader.java
+++ b/src/main/java/org/pantsbuild/jarjar/StringReader.java
@@ -24,7 +24,7 @@ abstract class StringReader extends ClassVisitor
     private String className;
 
     public StringReader() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
     
     abstract public void visitString(String className, String value, int line);
@@ -42,7 +42,7 @@ abstract class StringReader extends ClassVisitor
 
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         handleObject(value);
-        return new FieldVisitor(Opcodes.ASM4){
+        return new FieldVisitor(Opcodes.ASM5){
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 return StringReader.this.visitAnnotation(desc, visible);
@@ -52,7 +52,7 @@ abstract class StringReader extends ClassVisitor
     
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM4) {
+        return new AnnotationVisitor(Opcodes.ASM5) {
             @Override
             public void visit(String name, Object value) {
                 handleObject(value);
@@ -71,7 +71,7 @@ abstract class StringReader extends ClassVisitor
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        MethodVisitor mv = new MethodVisitor(Opcodes.ASM4){
+        MethodVisitor mv = new MethodVisitor(Opcodes.ASM5){
             @Override
             public void visitLdcInsn(Object cst) {
                 handleObject(cst);

--- a/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
+++ b/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
@@ -25,7 +25,7 @@ public class GetNameClassWriter extends ClassVisitor
     private String className;
     
     public GetNameClassWriter(int flags) {
-        super(Opcodes.ASM4,new ClassWriter(flags));
+        super(Opcodes.ASM5,new ClassWriter(flags));
     }
 
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {

--- a/src/test/java/org/pantsbuild/jarjar/integration/IntegrationTestBase.java
+++ b/src/test/java/org/pantsbuild/jarjar/integration/IntegrationTestBase.java
@@ -250,7 +250,7 @@ public abstract class IntegrationTestBase {
     }
     sb.append("public class ");
     sb.append(className);
-    sb.append(" { /* NOTHING TO SEE HERE */ }\n");
+    sb.append(" { public void test(int paramName) {} }\n"); // exercise ASM 5 handling of MethodParmeters attrtibute
 
     return sb.toString();
   }

--- a/src/test/java/org/pantsbuild/jarjar/integration/JavaVersionsTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/integration/JavaVersionsTest.java
@@ -48,6 +48,15 @@ public class JavaVersionsTest extends IntegrationTestBase {
     entries = getJarEntries(shaded);
     assertTrue("ShadedClass didn't make it into shaded jar (with rename rule).",
         entries.contains("org/pantsbuild/jarjar/ShadedClass.class"));
+
+    // TOOD write a test that demonstrates that KeepProcessor fails.
+    // I can trigger the ASM exception, but that gets caught and logged
+    shaded = shadeJar(jar, null, new String[] {
+         "rule org.pantsbuild.jarjar.SingleClass org.pantsbuild.jarjar.ShadedClass",
+         "keep org.pantsbuild.jarjar.**"
+    });
+    entries = getJarEntries(shaded);
+
   }
 
 
@@ -62,7 +71,11 @@ public class JavaVersionsTest extends IntegrationTestBase {
     String[] sources = {sourcePath};
 
     File folder = createTree(files);
-    assertTrue(tryCompile(folder, sources, "-source", javaVersion, "-target", javaVersion));
+    if (javaVersion != "1.6" && javaVersion != "1.7") {
+      assertTrue(tryCompile(folder, sources, "-source", javaVersion, "-target", javaVersion, "-parameters"));
+    } else {
+      assertTrue(tryCompile(folder, sources, "-source", javaVersion, "-target", javaVersion));
+    }
 
     for (String file : new FileTree(folder)) {
       if (file.endsWith(".java")) {


### PR DESCRIPTION
An alternative submission to #18 that tries to test
drive the change.

Some more finesse is needed to make the test case fail
without the `System.exit` in `KeepProcessor`.
