### PR TITLE
Add support for literals with dash

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/Wildcard.java
+++ b/src/main/java/org/pantsbuild/jarjar/Wildcard.java
@@ -40,7 +40,7 @@ class Wildcard
             throw new IllegalArgumentException("Not a valid package pattern: " + pattern);
         if (pattern.indexOf("***") >= 0)
             throw new IllegalArgumentException("The sequence '***' is invalid in a package pattern");
-        
+
         String regex = pattern;
         regex = replaceAllLiteral(dstar, regex, "(.+?)");
         regex = replaceAllLiteral(star, regex, "([^/]+)");
@@ -126,7 +126,8 @@ class Wildcard
           char c = expr.charAt(i);
           if (extra.indexOf(c) >= 0)
               continue;
-          if (!Character.isJavaIdentifierPart(c))
+          // Dash ('-') support added to support with scala packages
+          if (!(Character.isJavaIdentifierPart(c) || c == '-'))
               return false;
       }
       return true;

--- a/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
@@ -50,6 +50,7 @@ extends TestCase
 
       assertEquals("[Lfoo.example.Object;", remapper.mapValue("[Lorg.example.Object;"));
       assertEquals("foo.example.Object", remapper.mapValue("org.example.Object"));
+      assertEquals("foo.example-withdash.Object", remapper.mapValue("org.example-withdash.Object"));
       assertEquals("foo/example/Object", remapper.mapValue("org/example/Object"));
       assertEquals("foo/example.Object", remapper.mapValue("org/example.Object")); // path match
 

--- a/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
@@ -33,6 +33,8 @@ extends TestCase
         wildcard("net/sf/cglib/**", "foo/@1", "net/sf/cglib/!", null);
         wildcard("net/sf/cglib/*", "foo/@1", "net/sf/cglib/Bar", "foo/Bar");
         wildcard("net/sf/cglib/*/*", "foo/@2/@1", "net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
+        wildcard("com/akka-config/cglib/*/*", "foo/@2/@1", "com/akka-config/cglib/Bar/Baz", "foo/Baz/Bar");
+        wildcard("com/akka-config/cglib/**", "foo/@1", "com/akka-config/cglib/Bar/Baz", "foo/Bar/Baz");
     }
 
     private void wildcard(String pattern, String result, String value, String expect) {


### PR DESCRIPTION
### Motivation

Shading rule `rename` doesn't support such patterns as `"com.typesafe.akka.akka-http-core.*"` or `"com.typesafe.akka.akka-http-core.**"`.
Also during substitution of String literals in such case 

``` java
this.Daemonicity = this.config().getBoolean("akka.daemonic");
this.JvmExitOnFatalError = this.config().getBoolean("akka.jvm-exit-on-fatal-error");
```

some of them substitutes inconsistently and code starts to look like:

``` java
this.Daemonicity = this.config().getBoolean("shadeio.akka.daemonic");
this.JvmExitOnFatalError = this.config().getBoolean("akka.jvm-exit-on-fatal-error");
```
### Solution

Add dash as a valid symbol for identifiers.
### Disclaimer

I am not pretty sure in that solution (because have no experience in such low-level details) and that pull request is just conscripted to start a discussion.
Please be patient and provide your comments.
Thank you for your time.
