### PR TITLE
Upgrade to ASM6 to not fail on modules

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,14 +1,14 @@
 jar_library(
   name='asm',
   jars=[
-    jar('org.ow2.asm', 'asm', '5.2'),
+    jar('org.ow2.asm', 'asm', '6.0'),
   ]
 )
 
 jar_library(
   name='asm-commons',
   jars=[
-    jar('org.ow2.asm', 'asm-commons', '5.2'),
+    jar('org.ow2.asm', 'asm-commons', '6.0'),
   ]
 )
 

--- a/src/main/java/org/pantsbuild/jarjar/DepFindVisitor.java
+++ b/src/main/java/org/pantsbuild/jarjar/DepFindVisitor.java
@@ -25,7 +25,7 @@ import org.objectweb.asm.*;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.*;
 
-class DepFindVisitor extends RemappingClassAdapter
+class DepFindVisitor extends ClassRemapper
 {
     public DepFindVisitor(Map<String, String> classes, String source, DepHandler handler) throws IOException {
         super(null, new DepFindRemapper(classes, source, handler));

--- a/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
+++ b/src/main/java/org/pantsbuild/jarjar/EmptyClassVisitor.java
@@ -28,23 +28,23 @@ import org.objectweb.asm.Opcodes;
 public class EmptyClassVisitor extends ClassVisitor {
 
     public EmptyClassVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM6);
     }
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        return new MethodVisitor(Opcodes.ASM5) {};
+        return new MethodVisitor(Opcodes.ASM6) {};
     }
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM5) {};
+        return new AnnotationVisitor(Opcodes.ASM6) {};
     }
 
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-        return new FieldVisitor(Opcodes.ASM5) {};
+        return new FieldVisitor(Opcodes.ASM6) {};
     }
 
 }

--- a/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
+++ b/src/main/java/org/pantsbuild/jarjar/KeepProcessor.java
@@ -26,7 +26,7 @@ import org.objectweb.asm.commons.*;
 // TODO: this can probably be refactored into JarClassVisitor, etc.
 class KeepProcessor extends Remapper implements JarProcessor
 {
-    private final ClassVisitor cv = new RemappingClassAdapter(new EmptyClassVisitor(), this);
+    private final ClassVisitor cv = new ClassRemapper(new EmptyClassVisitor(), this);
     private final List<Wildcard> wildcards;
     private final List<String> roots = new ArrayList<String>();
     private final Map<String, Set<String>> depend = new HashMap<String, Set<String>>();

--- a/src/main/java/org/pantsbuild/jarjar/StringReader.java
+++ b/src/main/java/org/pantsbuild/jarjar/StringReader.java
@@ -24,7 +24,7 @@ abstract class StringReader extends ClassVisitor
     private String className;
 
     public StringReader() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM6);
     }
     
     abstract public void visitString(String className, String value, int line);
@@ -42,7 +42,7 @@ abstract class StringReader extends ClassVisitor
 
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         handleObject(value);
-        return new FieldVisitor(Opcodes.ASM5){
+        return new FieldVisitor(Opcodes.ASM6){
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 return StringReader.this.visitAnnotation(desc, visible);
@@ -52,7 +52,7 @@ abstract class StringReader extends ClassVisitor
     
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM5) {
+        return new AnnotationVisitor(Opcodes.ASM6) {
             @Override
             public void visit(String name, Object value) {
                 handleObject(value);
@@ -71,7 +71,7 @@ abstract class StringReader extends ClassVisitor
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        MethodVisitor mv = new MethodVisitor(Opcodes.ASM5){
+        MethodVisitor mv = new MethodVisitor(Opcodes.ASM6){
             @Override
             public void visitLdcInsn(Object cst) {
                 handleObject(cst);

--- a/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
+++ b/src/main/java/org/pantsbuild/jarjar/util/GetNameClassWriter.java
@@ -25,7 +25,7 @@ public class GetNameClassWriter extends ClassVisitor
     private String className;
     
     public GetNameClassWriter(int flags) {
-        super(Opcodes.ASM5,new ClassWriter(flags));
+        super(Opcodes.ASM6,new ClassWriter(flags));
     }
 
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {

--- a/src/main/java/org/pantsbuild/jarjar/util/RemappingClassTransformer.java
+++ b/src/main/java/org/pantsbuild/jarjar/util/RemappingClassTransformer.java
@@ -18,11 +18,11 @@ package org.pantsbuild.jarjar.util;
 
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.commons.Remapper;
-import org.objectweb.asm.commons.RemappingClassAdapter;
+import org.objectweb.asm.commons.ClassRemapper;
 
 import org.pantsbuild.jarjar.EmptyClassVisitor;
 
-public class RemappingClassTransformer extends RemappingClassAdapter
+public class RemappingClassTransformer extends ClassRemapper
 {
     public RemappingClassTransformer(Remapper pr) {
         super(new EmptyClassVisitor(), pr);


### PR DESCRIPTION
So this change allows jarjar to read jars and classes with Java 9 module info. It's the minimal change I needed to not fail while shading a jar with Java 9 module info in it.