### PR TITLE
Allow patterns to match classes under META-INF

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/Wildcard.java
+++ b/src/main/java/org/pantsbuild/jarjar/Wildcard.java
@@ -40,7 +40,7 @@ class Wildcard
             throw new IllegalArgumentException("Not a valid package pattern: " + pattern);
         if (pattern.indexOf("***") >= 0)
             throw new IllegalArgumentException("The sequence '***' is invalid in a package pattern");
-        
+
         String regex = pattern;
         regex = replaceAllLiteral(dstar, regex, "(.+?)");
         regex = replaceAllLiteral(star, regex, "([^/]+)");
@@ -121,6 +121,10 @@ class Wildcard
       // See 7.4.1.1 of the Java language spec for discussion.
       if (expr.endsWith("package-info")) {
           expr = expr.substring(0, expr.length() - "package-info".length());
+      }
+      // Allow patterns under META-INF if you want to match multi-release class files.
+      if (expr.startsWith("META-INF/")) {
+          expr = expr.substring("META-INF/".length(), expr.length());
       }
       for (int i = 0, len = expr.length(); i < len; i++) {
           char c = expr.charAt(i);

--- a/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
@@ -47,6 +47,8 @@ extends TestCase
       assertUnchangedValue("[Lorg.example.Object;;");
       assertUnchangedValue("[Lorg.example.Obj ct;");
       assertUnchangedValue("org.example/Object");
+      assertUnchangedValue("META-INF/org.example.Object");
+      assertUnchangedValue("META-INF/org.example.package-info");
 
       assertEquals("[Lfoo.example.Object;", remapper.mapValue("[Lorg.example.Object;"));
       assertEquals("foo.example.Object", remapper.mapValue("org.example.Object"));

--- a/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
@@ -33,6 +33,7 @@ extends TestCase
         wildcard("net/sf/cglib/**", "foo/@1", "net/sf/cglib/!", null);
         wildcard("net/sf/cglib/*", "foo/@1", "net/sf/cglib/Bar", "foo/Bar");
         wildcard("net/sf/cglib/*/*", "foo/@2/@1", "net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
+        wildcard("META-INF/versions/9/net/sf/cglib/*/*", "foo/@2/@1", "META-INF/versions/9/net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
     }
 
     private void wildcard(String pattern, String result, String value, String expect) {

--- a/src/test/java/org/pantsbuild/jarjar/ZapProcessorTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/ZapProcessorTest.java
@@ -1,0 +1,40 @@
+package org.pantsbuild.jarjar;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.Test;
+import org.pantsbuild.jarjar.util.EntryStruct;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ZapProcessorTest
+{
+  @Test
+  public void testZap() throws IOException {
+    Zap zap = new Zap();
+    zap.setPattern("org.**");
+    ZapProcessor zapProcessor = new ZapProcessor(Collections.singletonList(zap));
+
+    EntryStruct entryStruct = new EntryStruct();
+    entryStruct.name = "org/example/Object.class";
+    assertFalse(zapProcessor.process(entryStruct));
+
+    entryStruct.name = "com/example/Object.class";
+    assertTrue(zapProcessor.process(entryStruct));
+  }
+
+  @Test
+  public void testMetaInfZap() throws IOException {
+    Zap zap = new Zap();
+    zap.setPattern("META-INF.versions.9.**");
+    ZapProcessor zapProcessor = new ZapProcessor(Collections.singletonList(zap));
+
+    EntryStruct entryStruct = new EntryStruct();
+    entryStruct.name = "META-INF/versions/9/org/example/Object.class";
+    assertFalse(zapProcessor.process(entryStruct));
+
+    entryStruct.name = "META-INF/versions/8/com/example/Object.class";
+    assertTrue(zapProcessor.process(entryStruct));
+  }
+}


### PR DESCRIPTION
With Java9 you can have module classes under the META-INF directory of a jar.  It will probably have unintended consequences to shade those classes in a jar but this change allows you to shade those classes.  