### PR TITLE
Rebased: Add support for literals with dash

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/Wildcard.java
+++ b/src/main/java/org/pantsbuild/jarjar/Wildcard.java
@@ -130,7 +130,8 @@ class Wildcard
           char c = expr.charAt(i);
           if (extra.indexOf(c) >= 0)
               continue;
-          if (!Character.isJavaIdentifierPart(c))
+          // Dash ('-') support added to support with scala packages
+          if (!(Character.isJavaIdentifierPart(c) || c == '-'))
               return false;
       }
       return true;

--- a/src/main/java/org/pantsbuild/jarjar/Wildcard.java
+++ b/src/main/java/org/pantsbuild/jarjar/Wildcard.java
@@ -122,15 +122,11 @@ class Wildcard
       if (expr.endsWith("package-info")) {
           expr = expr.substring(0, expr.length() - "package-info".length());
       }
-      // Allow patterns under META-INF if you want to match multi-release class files.
-      if (expr.startsWith("META-INF/")) {
-          expr = expr.substring("META-INF/".length(), expr.length());
-      }
       for (int i = 0, len = expr.length(); i < len; i++) {
           char c = expr.charAt(i);
           if (extra.indexOf(c) >= 0)
               continue;
-          // Dash ('-') support added to support with scala packages
+          // Dash ('-') support added to accommodate class files under META-INF and scala packages.
           if (!(Character.isJavaIdentifierPart(c) || c == '-'))
               return false;
       }

--- a/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/PackageRemapperTest.java
@@ -52,6 +52,7 @@ extends TestCase
 
       assertEquals("[Lfoo.example.Object;", remapper.mapValue("[Lorg.example.Object;"));
       assertEquals("foo.example.Object", remapper.mapValue("org.example.Object"));
+      assertEquals("foo.example-withdash.Object", remapper.mapValue("org.example-withdash.Object"));
       assertEquals("foo/example/Object", remapper.mapValue("org/example/Object"));
       assertEquals("foo/example.Object", remapper.mapValue("org/example.Object")); // path match
 

--- a/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
@@ -34,6 +34,8 @@ extends TestCase
         wildcard("net/sf/cglib/*", "foo/@1", "net/sf/cglib/Bar", "foo/Bar");
         wildcard("net/sf/cglib/*/*", "foo/@2/@1", "net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
         wildcard("META-INF/versions/9/net/sf/cglib/*/*", "foo/@2/@1", "META-INF/versions/9/net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
+        wildcard("com/akka-config/cglib/*/*", "foo/@2/@1", "com/akka-config/cglib/Bar/Baz", "foo/Baz/Bar");
+        wildcard("com/akka-config/cglib/**", "foo/@1", "com/akka-config/cglib/Bar/Baz", "foo/Bar/Baz");
     }
 
     private void wildcard(String pattern, String result, String value, String expect) {


### PR DESCRIPTION
Rebased https://github.com/pantsbuild/jarjar/pull/22 to remove conflict and removed check for META-INF prefix that is no longer needed if `-` is considered a valid identifier.