### PR TITLE
Add oraclejdk9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   - JDK=openjdk7   WORKERS=6
   - JDK=oraclejdk7 WORKERS=6
   - JDK=oraclejdk8 WORKERS=6
+  - JDK=oraclejdk9 WORKERS=6
 
 script: |
   jdk_switcher use ${JDK}


### PR DESCRIPTION
Checking if all of the tests pass with oracle jdk 9.  

We can't add jdk 10 yet because it is still not available on Travis CI https://github.com/travis-ci/travis-ci/issues/9368