### PR TITLE
Be fine with class names with '$' inside patterns

### DIFF
--- a/src/main/java/org/pantsbuild/jarjar/Wildcard.java
+++ b/src/main/java/org/pantsbuild/jarjar/Wildcard.java
@@ -33,6 +33,24 @@ class Wildcard
     private final String[] strings;
     private final int[] refs;
 
+
+    private static String escapeComponents(String s) {
+        String[] parts = s.split("\\.", -1);
+        StringBuilder b = new StringBuilder();
+
+        for (int i = 0; i < parts.length; i++) {
+            if (i != 0)
+                b.append('.');
+
+            if (parts[i].contains("*"))
+                b.append(parts[i]);
+            else
+                b.append(Pattern.quote(parts[i]));
+        }
+
+        return b.toString();
+    }
+
     public Wildcard(String pattern, String result) {
         if (pattern.equals("**"))
             throw new IllegalArgumentException("'**' is not a valid pattern");
@@ -41,7 +59,7 @@ class Wildcard
         if (pattern.indexOf("***") >= 0)
             throw new IllegalArgumentException("The sequence '***' is invalid in a package pattern");
 
-        String regex = pattern;
+        String regex = escapeComponents(pattern);
         regex = replaceAllLiteral(dstar, regex, "(.+?)");
         regex = replaceAllLiteral(star, regex, "([^/]+)");
         regex = replaceAllLiteral(estar, regex, "*)");

--- a/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
+++ b/src/test/java/org/pantsbuild/jarjar/WildcardTest.java
@@ -36,6 +36,7 @@ extends TestCase
         wildcard("META-INF/versions/9/net/sf/cglib/*/*", "foo/@2/@1", "META-INF/versions/9/net/sf/cglib/Bar/Baz", "foo/Baz/Bar");
         wildcard("com/akka-config/cglib/*/*", "foo/@2/@1", "com/akka-config/cglib/Bar/Baz", "foo/Baz/Bar");
         wildcard("com/akka-config/cglib/**", "foo/@1", "com/akka-config/cglib/Bar/Baz", "foo/Bar/Baz");
+        wildcard("org/foo/Test$1", "shaded/@0", "org/foo/Test$1", "shaded/org/foo/Test$1");
     }
 
     private void wildcard(String pattern, String result, String value, String expect) {


### PR DESCRIPTION
This PR allows to have `$` signs appear in class names inside patterns, like
```java
Rule rule = new Rule();
rule.setPattern("org.something.Test$1");
rule.setResult("shaded.@0");
```
(renames `org.something.Test$1` to `shaded.org.something.Test$1`).

It cautiously escapes patterns in `org.pantsbuild.jarjar.Wildcard`, so that these are handled fine by regexes down the line.

Fixes https://github.com/pantsbuild/jarjar/issues/23.